### PR TITLE
Add signature validation to REST.ZAUTHENTICATE

### DIFF
--- a/rtn/REST.ZAUTHENTICATE.mac
+++ b/rtn/REST.ZAUTHENTICATE.mac
@@ -1,3 +1,4 @@
+ROUTINE REST.ZAUTHENTICATE
 ZAUTHENTICATE(ServiceName, Namespace, Username, Password, Credentials, Properties) Public
 {
 #include %occErrors
@@ -34,7 +35,11 @@ ZAUTHENTICATE(ServiceName, Namespace, Username, Password, Credentials, Propertie
 			// if the access token is not a JWT, we would need to validate the access token
 			// using another means such as the introspection or userinfo endpoint.
 			if $$$ISOK(sc) {
-				set valid=##class(%SYS.OAuth2.Validation).ValidateJWT(applicationName,accessToken,,,.jsonObject,,.sc)
+				set valid=##class(%SYS.OAuth2.Validation).ValidateJWT(applicationName,accessToken,,,.jsonObject,.securityParams,.sc)
+				set isTokenSigned = $Data(securityParams("sigalg"))#2
+				if 'isTokenSigned {
+					$$$ThrowStatus($System.Status.Error($$$AccessDenied))
+				}
 			}
 			
 			if valid {
@@ -53,10 +58,10 @@ ZAUTHENTICATE(ServiceName, Namespace, Username, Password, Credentials, Propertie
 				set Properties("FullName")="OAuth account "_Username
 				set Properties("Username")=Username
 				set Properties("Password")=""	// we don't really care about oauth2 account password
-.
+
 				// Set the roles and other Properties as appropriate.
 				set Properties("Roles")=roles
-.
+
 			} else {
 				set errorText=$system.Status.GetErrorText(sc)
 			}


### PR DESCRIPTION
From [documentation](https://docs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=GOAUTH_client#GOAUTH_client_examinetoken):

> Because the Oauth specification allows an application to accept both signed and unsigned JWTs, the ValidateJWT method does not reject an unsigned JWT. However, in many cases it is strongly recommended that your application implement stricter security by rejecting an unsigned JWT.

Without signature verification, an attacker can easily spoof an access token to gain access to the REST API.