### PR TITLE
Fix state parameter indexing in GetCredentials

### DIFF
--- a/rtn/OAUTH2.ZAUTHENTICATE.mac
+++ b/rtn/OAUTH2.ZAUTHENTICATE.mac
@@ -96,7 +96,7 @@ ZAUTHENTICATE(ServiceName, Namespace, Username, Password, Credentials, Propertie
 	quit sc
 }
 GetCredentials(ServiceName,Namespace,Username,Password,Credentials) Public {
-	if ServiceName="%Service_WebGateway", $data(%request.Data(##class(%OAuth2.Login).#SessionQueryParameter),state) {
+	if ServiceName="%Service_WebGateway", $data(%request.Data(##class(%OAuth2.Login).#SessionQueryParameter,1),state) {
 		// Supply user name and password for authentication via a subclass of %OAuth2.Login
 		Set HashedToken = $zcrc(state,7) 
 		set Username="OAuth2"_HashedToken


### PR DESCRIPTION
In an SSO authentication configuration, it was detected that the ZAUTHENTICATE routine was causing an error due to a missing parameter in the function. To correct this, the following adjustment was made to the call:

From:
if ServiceName="%Service_WebGateway", $data(%request.Data(##class(%OAuth2.Login).#SessionQueryParameter),state)
To:
if ServiceName="%Service_WebGateway", $data(%request.Data(##class(%OAuth2.Login).#SessionQueryParameter,1),state)